### PR TITLE
Fix in README + max roll string

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A browser extension that we're working on to help GMs spend more time telling a 
 
 ##Installation
 rpjeeves isn't quite ready for release, but if you're anxious to try it out, you can get your hands a little dirty and install the unpacked, unfinished version.
-First, you need to clone or fork the repo. Then, read [https://developer.chrome.com/extensions/getstarted#unpacked](these) instructions on installing unpacked chrome extensions.
+First, you need to clone or fork the repo. Then, read [these](https://developer.chrome.com/extensions/getstarted#unpacked) instructions on installing unpacked chrome extensions.
 
 ##Feedback
 If you do choose to use rpjeeves in this unpacked, unreleased state, we would be tickled to get your feedback. Please use the github issue tracker to report your bugs, and be as descriptive as possible. We are especially interested to hear about SRDs that are not compatible with rpjeeves.

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -101,7 +101,8 @@ function roll(numDice, die, modifier){
 	modifierInt = parseInt(modifier);
 	dieInt = parseInt(die);
 	numDiceInt = parseInt(numDice);
-	var rawRoll = 0;
+	var maxRoll = numDiceInt * dieInt + modifierInt;
+    var rawRoll = 0;
 	var rollString = "";
 	for (i = 0; i < numDiceInt; i++)
 	{
@@ -118,7 +119,7 @@ function roll(numDice, die, modifier){
 			rollString = rawRoll;
 		}
 	}
-	return numDice + "d" + die + "(" + rollString + ")" + modifier + " = " + "<span style='font-size: 15px' class='label label-primary'>" + (rawRoll + modifierInt) + "</span>";
+	return numDice + "d" + die + "(" + rollString + ")" + modifier + " = " + "<span style='font-size: 15px' class='label label-primary'>" + (rawRoll + modifierInt) + "</span> / " + maxRoll;
 }
 
 //attackStrings will look like this: "+36 or +36/+12/+9 etc..."

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -102,7 +102,7 @@ function roll(numDice, die, modifier){
 	dieInt = parseInt(die);
 	numDiceInt = parseInt(numDice);
 	var maxRoll = numDiceInt * dieInt + modifierInt;
-    var rawRoll = 0;
+	var rawRoll = 0;
 	var rollString = "";
 	for (i = 0; i < numDiceInt; i++)
 	{


### PR DESCRIPTION
URL and text were switched in the readme.

I also usually use the maximum hit points for monsters, so I added the max roll to the popover
![ss](https://www.Scolab.com/Public/Jing/MF/maxdiceroll.png)
